### PR TITLE
Added duplicate field support and fixed issue with child name same as parent name.

### DIFF
--- a/multicardinal-field-splitter-processor/pom.xml
+++ b/multicardinal-field-splitter-processor/pom.xml
@@ -1,49 +1,40 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>com.esri.geoevent.parent</groupId>
-		<artifactId>multicardinal-field-splitter</artifactId>
-		<version>10.6.0</version>
-	</parent>
-	<groupId>com.esri.geoevent.processor</groupId>
-	<artifactId>multicardinal-field-splitter-processor</artifactId>
-	<name>Esri :: GeoEvent :: Processor :: MulticardinalFieldSplitter</name>
-	<packaging>bundle</packaging>
-	<dependencies>
-		<dependency>
-			<groupId>org.apache.felix</groupId>
-			<artifactId>org.osgi.compendium</artifactId>
-			<version>1.4.0</version>
-			<scope>provided</scope>
-		</dependency>
-	</dependencies>	
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<version>2.3.6</version>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
-						<Bundle-ContactAddress>${sdk.contact.address}</Bundle-ContactAddress>
-						<Bundle-Version>${project.version}</Bundle-Version>
-						<Export-Package/>
-						<Private-Package>com.esri.geoevent.processor.multicardinalfieldsplitter</Private-Package>
-					</instructions>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.esri.geoevent.parent</groupId>
+    <artifactId>multicardinal-field-splitter</artifactId>
+    <version>10.4.0</version>
+  </parent>
+  <groupId>com.esri.geoevent.processor</groupId>
+  <artifactId>multicardinal-field-splitter-processor</artifactId>
+  <name>Esri :: GeoEvent :: Processor :: MulticardinalFieldSplitter</name>
+  <packaging>bundle</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.util.tracker</artifactId>
+      <version>1.5.2</version>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+            <Bundle-ContactAddress>${sdk.contact.address}</Bundle-ContactAddress>
+            <Bundle-Version>${project.version}</Bundle-Version>
+            <AGES-Domain>com.esri.geoevent.processor</AGES-Domain>
+            <Export-Package />
+            <Private-Package>com.esri.geoevent.processor.multicardinalfieldsplitter</Private-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/multicardinal-field-splitter-processor/src/main/java/com/esri/geoevent/processor/multicardinalfieldsplitter/MulticardinalFieldSplitterDefinition.java
+++ b/multicardinal-field-splitter-processor/src/main/java/com/esri/geoevent/processor/multicardinalfieldsplitter/MulticardinalFieldSplitterDefinition.java
@@ -69,7 +69,7 @@ public class MulticardinalFieldSplitterDefinition extends GeoEventProcessorDefin
   @Override
   public String getDescription()
   {
-    return "Release 6: Split multi-cardinal group fields into individual GeoEvents. For fields of type 'Group' that have cardinality set a 'Many', this processor will create a copy of the incoming event for each child of the specified group field. The attributes of each child will be promoted up one level. All other attributes of the original event will be preserved. Any promoted field whose name collides with an existing name, will be modified to include '__#' at the end (where # will be a unique number).";
+    return "Release 8: Split multi-cardinal group fields into individual GeoEvents. For fields of type 'Group' that have cardinality set a 'Many', this processor will create a copy of the incoming event for each child of the specified group field. The attributes of each child will be promoted up one level. All other attributes of the original event will be preserved. Any promoted field whose name collides with an existing name, will be modified to include the parent field name as a prefix and possibly '__#' at the end (where # will be a unique number).";
   }
 
   @Override

--- a/multicardinal-field-splitter-processor/src/main/java/com/esri/geoevent/processor/multicardinalfieldsplitter/MulticardinalFieldSplitterDefinition.java
+++ b/multicardinal-field-splitter-processor/src/main/java/com/esri/geoevent/processor/multicardinalfieldsplitter/MulticardinalFieldSplitterDefinition.java
@@ -39,19 +39,13 @@ public class MulticardinalFieldSplitterDefinition extends GeoEventProcessorDefin
   {
     try
     {
-      propertyDefinitions.put("fieldToSplit", new PropertyDefinition("fieldToSplit", PropertyType.String, "MyField", "Field to Split", "Field name its children to be split into individual GeoEvents", false, false));
-      propertyDefinitions.put("newGeoEventDefinitionName", new PropertyDefinition("newGeoEventDefinitionName", PropertyType.String, "FieldgroupSplitter", "Resulting GeoEvent Definition Name", "FieldSplitter", false, false));
+      propertyDefinitions.put("fieldToSplit", new PropertyDefinition("fieldToSplit", PropertyType.String, "MyField", "Field to Split", "The name of a group field to have its children to be split into individual GeoEvents. One event will be created for each child of this group field. The group field will be removed from the resulting GeoEvent Definition, and child fields will be promoted.", true, false));
+      propertyDefinitions.put("newGeoEventDefinitionName", new PropertyDefinition("newGeoEventDefinitionName", PropertyType.String, "FieldgroupSplitter", "New GeoEvent Definition Name", "The name of the new GeoEvent Definition that will be created.", true, false));
     }
     catch (Exception e)
     {
       LOG.error("Error setting up Multicardinal Field Splitter Definition.", e);
     }
-  }
-
-  @Override
-  public String getVersion()
-  {
-    return "10.6.0";
   }
 
   @Override
@@ -75,13 +69,13 @@ public class MulticardinalFieldSplitterDefinition extends GeoEventProcessorDefin
   @Override
   public String getDescription()
   {
-    return "Split multi cardinality field into individual GeoEvents";
+    return "Release 6: Split multi-cardinal group fields into individual GeoEvents. For fields of type 'Group' that have cardinality set a 'Many', this processor will create a copy of the incoming event for each child of the specified group field. The attributes of each child will be promoted up one level. All other attributes of the original event will be preserved. Any promoted field whose name collides with an existing name, will be modified to include '__#' at the end (where # will be a unique number).";
   }
 
   @Override
   public String getContactInfo()
   {
-    return "mpilouk@esri.com";
+    return "geoevent@esri.com";
   }
 
 }

--- a/multicardinal-field-splitter-processor/src/main/java/com/esri/geoevent/processor/multicardinalfieldsplitter/MulticardinalFieldSplitterService.java
+++ b/multicardinal-field-splitter-processor/src/main/java/com/esri/geoevent/processor/multicardinalfieldsplitter/MulticardinalFieldSplitterService.java
@@ -34,7 +34,7 @@ import com.esri.ges.processor.GeoEventProcessorServiceBase;
 
 public class MulticardinalFieldSplitterService extends GeoEventProcessorServiceBase
 {
-  private Messaging messaging;
+  private Messaging        messaging;
   final private static Log LOG = LogFactory.getLog(MulticardinalFieldSplitterService.class);
 
   public MulticardinalFieldSplitterService()

--- a/multicardinal-field-splitter-processor/src/main/resources/OSGI-INF/blueprint/config.xml
+++ b/multicardinal-field-splitter-processor/src/main/resources/OSGI-INF/blueprint/config.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
-	<reference id="messagingService" interface="com.esri.ges.messaging.Messaging" timeout="1000"/>
-	<bean id="multicardinalFieldSplitterServiceBean" class="com.esri.geoevent.processor.multicardinalfieldsplitter.MulticardinalFieldSplitterService" activation="eager">
-		<property name="bundleContext" ref="blueprintBundleContext"/>
-		<property name="messaging" ref="messagingService"/>
-	</bean>
-	<service id="MulticardinalFieldSplitterService" ref="multicardinalFieldSplitterServiceBean" interface="com.esri.ges.processor.GeoEventProcessorService">
-		<service-properties>
-			<entry key="threadSafe" value="false"/>
-		</service-properties>
-	</service>
+  <reference id="messagingService" interface="com.esri.ges.messaging.Messaging" timeout="1000" />
+  <bean id="multicardinalFieldSplitterServiceBean" class="com.esri.geoevent.processor.multicardinalfieldsplitter.MulticardinalFieldSplitterService" activation="eager">
+    <property name="bundleContext" ref="blueprintBundleContext" />
+    <property name="messaging" ref="messagingService" />
+  </bean>
+  <service id="MulticardinalFieldSplitterService" ref="multicardinalFieldSplitterServiceBean" interface="com.esri.ges.processor.GeoEventProcessorService">
+    <service-properties>
+      <entry key="threadSafe" value="false" />
+    </service-properties>
+  </service>
 </blueprint>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.bundle.plugin.version>4.0.0</maven.bundle.plugin.version>
     <junit.version>4.8.1</junit.version>
-    <project.release>6</project.release>
+    <project.release>8</project.release>
   </properties>
   <modules>
     <module>multicardinal-field-splitter-processor</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1,77 +1,60 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-
-	<groupId>com.esri.geoevent.parent</groupId>
-	<artifactId>multicardinal-field-splitter</artifactId>
-	<version>10.6.0</version>
-	<packaging>pom</packaging>
-
-	<name>Esri :: GeoEvent :: MulticardinalFieldSplitter</name>
-	<url>http://www.esri.com</url>
-
-	<properties>
-		<contact.address>geoevent@esri.com</contact.address>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.bundle.plugin.version>2.3.6</maven.bundle.plugin.version>
-		<junit.version>4.8.1</junit.version>
-	</properties>
-
-	<modules>
-		<module>multicardinal-field-splitter-processor</module>
-	</modules>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>commons-logging</groupId>
-				<artifactId>commons-logging</artifactId>
-				<version>1.1.1</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
-	<dependencies>
-	
-		<dependency>
-			<groupId>com.esri.geoevent.sdk</groupId>
-			<artifactId>geoevent-sdk</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
-		</dependency>
-	 
-		<!-- 
-		<dependency>
-			<groupId>com.esri.ges.sdk</groupId>
-			<artifactId>ges-lib</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		-->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>${junit.version}</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.felix</groupId>
-					<artifactId>maven-bundle-plugin</artifactId>
-					<extensions>true</extensions>
-					<version>${maven.bundle.plugin.version}</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.5.1</version>
-					<configuration>
-						<source>1.8</source>
-						<target>1.8</target>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.esri.geoevent.parent</groupId>
+  <artifactId>multicardinal-field-splitter</artifactId>
+  <version>10.4.0</version>
+  <packaging>pom</packaging>
+  <name>Esri :: GeoEvent :: MulticardinalFieldSplitter</name>
+  <url>http://www.esri.com</url>
+  <properties>
+    <contact.address>geoevent@esri.com</contact.address>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.bundle.plugin.version>4.0.0</maven.bundle.plugin.version>
+    <junit.version>4.8.1</junit.version>
+    <project.release>6</project.release>
+  </properties>
+  <modules>
+    <module>multicardinal-field-splitter-processor</module>
+  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>com.esri.geoevent.sdk</groupId>
+      <artifactId>geoevent-sdk</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <extensions>true</extensions>
+          <version>${maven.bundle.plugin.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <source>1.8</source>
+            <target>1.8</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>


### PR DESCRIPTION
- Fixed issue where fields with the same name as the split field would not be present in the final output events (Example: “location”: {“location”:”New York”,”lat”:38.1234,”lon”:-121.1234} )

- Changed the childindex field name to childindex__# where the # is now unique.
       + If multiple field splitters are used in a row, each one will create a new childindex__# field.
       + Avoids the “duplicate field” error previously encountered or the requirement to field map 
 between splitters to rename the childindex field.

- Duplicate field names from multi-cardinal  groups will be renamed with a unique __# appended to the end of the field name.